### PR TITLE
Fix use_timeslots mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 1.3.1
 
-- Updating `Product.use_timeslot` to `Product.use_timeslots` in supplier tester and mock server.
+- Update `Product.use_timeslot` to `Product.use_timeslots` in supplier tester and mock server.
+- Make `product-id` not required on product catalog tests.
 
 ## 1.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.1
+
+- Updating `Product.use_timeslot` to `Product.use_timeslots` in supplier tester and mock server.
+
 ## 1.3.0
 
 - Adding product catalog endpoint

--- a/supplier_api_tester/README.md
+++ b/supplier_api_tester/README.md
@@ -21,7 +21,7 @@ Usage: supplier_tester [OPTIONS]
 Options:
   -u, --url TEXT         [required]
   -k, --api-key TEXT     [required]
-  -p, --product-id TEXT  [required]
+  -p, --product-id TEXT  Product ID to call tests on. Required with -a and -t flags
   -t, --timeslots        Use timeslots
   -a, --availability     Run availability tests
   -r, --reservation      Run reservation tests

--- a/supplier_api_tester/README.md
+++ b/supplier_api_tester/README.md
@@ -33,11 +33,15 @@ Options:
 Running all tests:
 
 ```sh
-    supplier_tester -u 'http://localhost:8000' -k 'secret' -p 'A400-FX'
+    supplier_tester -u 'http://localhost:8000' -k 'secret' -p 'A500-FX'  # For products without timeslots
+    supplier_tester -u 'http://localhost:8000' -k 'secret' -p 'A400-FX' -t  # For products with timeslots
 ```
+
+**Remember to choose valid product id. It has to refer timeslotted product when you use `-t` flag.**
 
 Running only availability tests:
 
 ```sh
-    supplier_tester -u 'http://localhost:8000' -k 'secret' -p 'A400-FX' -a
+    supplier_tester -u 'http://localhost:8000' -k 'secret' -p 'A500-FX' -a  # For products without timeslots
+    supplier_tester -u 'http://localhost:8000' -k 'secret' -p 'A400-FX' -a -t  # For products with timeslots
 ```

--- a/supplier_api_tester/setup.py
+++ b/supplier_api_tester/setup.py
@@ -8,7 +8,7 @@ with open('requirements.txt') as f:
 
 setuptools.setup(
     name='Supplier API tester',
-    version='1.3.0',
+    version='1.3.1',
     author='Tiqets Team',
     author_email='connections@tiqets.com',
     description='Console tool for validating the Supplier API implementation',

--- a/supplier_api_tester/supplier_api_tester/cli.py
+++ b/supplier_api_tester/supplier_api_tester/cli.py
@@ -15,7 +15,7 @@ def print_title(title):
 @click.command()
 @click.option('-u', '--url', required=True, prompt='Server URL', type=str)
 @click.option('-k', '--api-key', required=True, prompt='API Key', type=str)
-@click.option('-p', '--product-id', required=True, prompt='Product ID', type=str)
+@click.option('-p', '--product-id', type=str, help='Product ID to call tests on. Required with -a and -t flags')
 @click.option('-t', '--timeslots', is_flag=True, default=False, help='Use timeslots')
 @click.option('-a', '--availability', is_flag=True, default=False, help='Run availability tests')
 @click.option('-r', '--reservation', is_flag=True, default=False, help='Run reservation tests')
@@ -29,6 +29,9 @@ def supplier_tester(url, api_key, product_id, timeslots, availability, reservati
         reservation = True
         booking = True
         catalog = True
+
+    if any((availability, timeslots, reservation, booking)) and not product_id:
+        product_id = click.prompt('Product ID')
 
     if availability:
         print_title('AVAILABILITY TESTS')

--- a/supplier_api_tester/supplier_api_tester/models.py
+++ b/supplier_api_tester/supplier_api_tester/models.py
@@ -34,7 +34,7 @@ class TestResult:
 class Product:
     id: str
     name: str
-    use_timeslot: bool
+    use_timeslots: bool
     description: Optional[str]
 
 @dataclass

--- a/supplier_api_tester/supplier_api_tester/tests/product_catalog.py
+++ b/supplier_api_tester/supplier_api_tester/tests/product_catalog.py
@@ -21,7 +21,7 @@ def test_get_timeslots_products(api_url, api_key, version=1):
     '''Get product catalog with use_timeslots=true query filter'''
 
     url = f'{api_url}/v{version}/products'
-    response = client(url, api_key, method=requests.get, params={'use_timeslot': True})
+    response = client(url, api_key, method=requests.get, params={'use_timeslots': True})
     products = get_products(response)
     _validate_timeslots(products, use_timeslots=True)
     return TestResult()
@@ -32,7 +32,7 @@ def test_get_no_timeslots_products(api_url, api_key, version=1):
     '''Get product catalog with use_timeslots=false query filter'''
 
     url = f'{api_url}/v{version}/products'
-    response = client(url, api_key, method=requests.get, params={'use_timeslot': True})
+    response = client(url, api_key, method=requests.get, params={'use_timeslots': True})
     products = get_products(response)
     _validate_timeslots(products, use_timeslots=False)
     return TestResult()
@@ -40,5 +40,5 @@ def test_get_no_timeslots_products(api_url, api_key, version=1):
 
 def _validate_timeslots(products, use_timeslots):
     for product in products:
-        if product.use_timeslot != use_timeslots:
+        if product.use_timeslots != use_timeslots:
             raise FailedTest(f'Product {product.id} with non matching use_timeslots returned')

--- a/supplier_server_mock/setup.py
+++ b/supplier_server_mock/setup.py
@@ -8,7 +8,7 @@ with open('requirements.txt') as f:
 
 setuptools.setup(
     name='Supplier API mock server',
-    version='1.3.0',
+    version='1.3.1',
     author='Tiqets Team',
     author_email='connections@tiqets.com',
     description='Mock Server with Supplier API implementation',

--- a/supplier_server_mock/supplier_server/app.py
+++ b/supplier_server_mock/supplier_server/app.py
@@ -17,9 +17,9 @@ app.register_error_handler(exceptions.BadRequest, error_handlers.bad_request)
 @app.route('/v1/products')
 @authorization_header
 def products():
-    use_timeslot = request.args.get('use_timeslot')
-    if use_timeslot is not None:
-        return jsonify([p for p in constants.PRODUCTS if p['use_timeslot'] == use_timeslot])
+    use_timeslots = request.args.get('use_timeslots')
+    if use_timeslots is not None:
+        return jsonify([p for p in constants.PRODUCTS if p['use_timeslots'] == use_timeslots])
     return jsonify([p for p in constants.PRODUCTS])
 
 

--- a/supplier_server_mock/supplier_server/constants.py
+++ b/supplier_server_mock/supplier_server/constants.py
@@ -1,8 +1,8 @@
 PRODUCTS = [
-    {'id': 'A300-FX', 'name': 'A300-FX', 'use_timeslot': True},
-    {'id': 'A400-FX', 'name': 'A400-FX', 'use_timeslot': True, 'description': 'Test timeslot product'},
-    {'id': 'A500-FX', 'name': 'A500-FX', 'use_timeslot': False, 'description': 'Test non timeslot product'},
-    {'id': 'A600-FX', 'name': 'A600-FX', 'use_timeslot': False},
+    {'id': 'A300-FX', 'name': 'A300-FX', 'use_timeslots': True},
+    {'id': 'A400-FX', 'name': 'A400-FX', 'use_timeslots': True, 'description': 'Test timeslot product'},
+    {'id': 'A500-FX', 'name': 'A500-FX', 'use_timeslots': False, 'description': 'Test non timeslot product'},
+    {'id': 'A600-FX', 'name': 'A600-FX', 'use_timeslots': False},
 ]
 VARIANTS = ('Adult', 'Child')
 MAX_DATE_RANGE = 6  # in months

--- a/supplier_server_mock/supplier_server/utils.py
+++ b/supplier_server_mock/supplier_server/utils.py
@@ -24,14 +24,14 @@ def check_product_id(product_id: str):
 
 
 def check_timeslot_product(product_id: str):
-    if product_id not in [p['id'] for p in PRODUCTS if p['use_timeslot']]:
+    if product_id not in [p['id'] for p in PRODUCTS if p['use_timeslots']]:
         raise BadRequest(
             1002, 'Timeslot product expected', f'Requested timeslot availability for non timeslot product ID {product_id}'
         )
 
 
 def check_non_timeslot_product(product_id: str):
-    if product_id not in [p['id'] for p in PRODUCTS if not p['use_timeslot']]:
+    if product_id not in [p['id'] for p in PRODUCTS if not p['use_timeslots']]:
         raise BadRequest(
             1003, 'Non-timeslot product expected', f'Requested non timeslot availability for timeslot product ID {product_id}'
         )


### PR DESCRIPTION
`Product.use_timeslots` in specification was not matching `Product.use_timeslot` in mock server and tester. 
Fixed all to use `Product.use_timeslots`