### PR TITLE
Fix date format in API error mssages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.2
+
+- Fix date format display in API errors.
+
 ## 1.3.1
 
 - Update `Product.use_timeslot` to `Product.use_timeslots` in supplier tester and mock server.

--- a/api.yaml
+++ b/api.yaml
@@ -236,7 +236,7 @@ paths:
             |---------------------|-----------------------|------------------------------------------------------------------------------------------|
             |                1000 | Missing argument      | Required argument ATTRIBUTE_NAME was not found                                           |
             |                1001 | Missing product       | Product with ID ID_NUMBER doesn't exist                                                  |
-            |                2000 | Incorrect date format | Incorrect date format xxx, please use the YYYY-dd-mm format                              |
+            |                2000 | Incorrect date format | Incorrect date format xxx, please use the YYYY-MM-DD format                              |
             |                2001 | Incorrect date range  | The end date cannot be earlier then start date                                           |
             |                2009 | Incorrect date        | Eg. Cannot use the past date or Given date is too far ahead in the future (max 6 months) |
           content:
@@ -296,7 +296,7 @@ paths:
             |                1000 | Missing argument              | Required argument ATTRIBUTE_NAME was not found                                           |
             |                1001 | Missing product               | Product with ID ID_NUMBER doesn't exist                                                  |
             |                1003 | Non-timeslot product expected | Requested non timeslot availability for timeslot product ID ID_NUMBER                    |
-            |                2000 | Incorrect date format         | Incorrect date format xxx, please use the YYYY-dd-mm format                              |
+            |                2000 | Incorrect date format         | Incorrect date format xxx, please use the YYYY-MM-DD format                              |
             |                2001 | Incorrect date range          | The end date cannot be earlier then start date                                           |
             |                2009 | Incorrect date                | Eg. Cannot use the past date or Given date is too far ahead in the future (max 6 months) |
           content: {}
@@ -354,7 +354,7 @@ paths:
             |                1000 | Missing argument          | Required argument ATTRIBUTE_NAME was not found                                           |
             |                1001 | Missing product           | Product with ID ID_NUMBER doesn't exist                                                  |
             |                1002 | Timeslot product expected | Requested timeslot availability for non timeslot product ID ID_NUMBER                    |
-            |                2000 | Incorrect date format     | Incorrect date format xxx, please use the YYYY-dd-mm format                              |
+            |                2000 | Incorrect date format     | Incorrect date format xxx, please use the YYYY-MM-DD format                              |
             |                2001 | Incorrect date range      | The end date cannot be earlier then start date                                           |
             |                2009 | Incorrect date            | Eg. Cannot use the past date or Given date is too far ahead in the future (max 6 months) |
           content: {}
@@ -406,8 +406,8 @@ paths:
             |---------------------|--------------------------------|-----------------------------------------------------------------------------------------------|
             |                1000 | Missing argument               | Required argument ATTRIBUTE_NAME was not found                                                |
             |                1001 | Missing product                | Product with ID ID_NUMBER doesn't exist                                                       |
-            |                2000 | Incorrect date format          | Incorrect date format xxx, please use the YYYY-dd-mm format                                   |
-            |                2002 | Wrong time slot ID             | Given timeslot_id doesn't belong to given date (YYYY-dd-mm)                                   |
+            |                2000 | Incorrect date format          | Incorrect date format xxx, please use the YYYY-MM-DD format                                   |
+            |                2002 | Wrong time slot ID             | Given timeslot_id doesn't belong to given date (YYYY-MM-DD)                                   |
             |                2003 | Wrong variant ID               | Given variant_id doesn't belong to given timeslot_id (TIMESLOT_ID)                            |
             |                2004 | Incorrect type                 | Expected ATTRIBUTE_NAME to be a string, got TYPE instead                                      |
             |                2005 | Invalid Value                  | Eg. The phone number must not contain dots.                                                   |

--- a/supplier_api_tester/setup.py
+++ b/supplier_api_tester/setup.py
@@ -8,7 +8,7 @@ with open('requirements.txt') as f:
 
 setuptools.setup(
     name='Supplier API tester',
-    version='1.3.1',
+    version='1.3.2',
     author='Tiqets Team',
     author_email='connections@tiqets.com',
     description='Console tool for validating the Supplier API implementation',

--- a/supplier_api_tester/supplier_api_tester/tests/reservation.py
+++ b/supplier_api_tester/supplier_api_tester/tests/reservation.py
@@ -154,7 +154,7 @@ def test_incorrect_date_format(api_url, api_key, product_id, timeslots: bool, ve
     expected_error = ApiError(
         error_code=2000,
         error='Incorrect date format',
-        message=f'Incorrect date format {bad_date_format}, please use the YYYY-dd-mm format',
+        message=f'Incorrect date format {bad_date_format}, please use the YYYY-MM-DD format',
     )
     check_api_error(api_error, expected_error)
     return TestResult()

--- a/supplier_api_tester/supplier_api_tester/utils/availability.py
+++ b/supplier_api_tester/supplier_api_tester/utils/availability.py
@@ -216,7 +216,7 @@ def incorrect_date_format(api_url, api_key, product_id, endpoint, version=1):
     expected_error = ApiError(
         error_code=2000,
         error='Incorrect date format',
-        message=f'Incorrect date format {bad_date_format}, please use the YYYY-dd-mm format',
+        message=f'Incorrect date format {bad_date_format}, please use the YYYY-MM-DD format',
     )
     check_api_error(api_error, expected_error)
 
@@ -229,7 +229,7 @@ def incorrect_date_format(api_url, api_key, product_id, endpoint, version=1):
     expected_error = ApiError(
         error_code=2000,
         error='Incorrect date format',
-        message=f'Incorrect date format {bad_date_format}, please use the YYYY-dd-mm format',
+        message=f'Incorrect date format {bad_date_format}, please use the YYYY-MM-DD format',
     )
     check_api_error(api_error, expected_error)
 

--- a/supplier_server_mock/setup.py
+++ b/supplier_server_mock/setup.py
@@ -8,7 +8,7 @@ with open('requirements.txt') as f:
 
 setuptools.setup(
     name='Supplier API mock server',
-    version='1.3.1',
+    version='1.3.2',
     author='Tiqets Team',
     author_email='connections@tiqets.com',
     description='Mock Server with Supplier API implementation',

--- a/supplier_server_mock/supplier_server/utils.py
+++ b/supplier_server_mock/supplier_server/utils.py
@@ -15,7 +15,7 @@ def get_date(data, name, required=True):
     try:
         return date.fromisoformat(data_str)
     except ValueError:
-        raise BadRequest(2000, 'Incorrect date format', f'Incorrect date format {data_str}, please use the YYYY-dd-mm format')
+        raise BadRequest(2000, 'Incorrect date format', f'Incorrect date format {data_str}, please use the YYYY-MM-DD format')
 
 
 def check_product_id(product_id: str):


### PR DESCRIPTION
Correct format is `YYYY-MM-DD` not `YYYY-dd-mm`