### PR TITLE
Changed the old e-mail address to the new one

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -121,7 +121,7 @@ info:
 
     If your development environment can be accessed from the web (directly or via a tunneling service like [ngrok](https://ngrok.com/)) then [**our online test tool**](https://supplier-api-web-tool.tiqets.com/) is the way to go.
 
-    If you haven’t received the credentials yet please request them via connections@tiqets.com
+    If you haven’t received the credentials yet please request them via apisupport@tiqets.com
 
     [![webtool screenshot](https://raw.githubusercontent.com/Tiqets/supplier-api/master/docs/webtool.png)](https://supplier-api-web-tool.tiqets.com/)
 
@@ -144,7 +144,7 @@ info:
     [![mock server screenshot](https://raw.githubusercontent.com/Tiqets/supplier-api/master/docs/mockserver.png)](https://github.com/Tiqets/supplier-api/tree/master/supplier_server_mock)
 
   contact:
-    email: connections@tiqets.com
+    email: apisupport@tiqets.com
   version: 1.6.0
 tags:
   - name: Availability


### PR DESCRIPTION
We were still mentioning connections@tiqets.com here so I've changed that to apisupport@tiqets.com