### PR TITLE
apply minor syntactic changes

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Tiqets Supplier API
-  version: 2.2.0
+  version: 2.2.1
   description: |
     The Tiqets Supplier API Specification allows Tiqets' Supply Partners to connect their booking systems to Tiqets.com
     if they aren't connected already.
@@ -165,6 +165,9 @@ info:
   contact:
     name: "Tiqets API Support"
     email: apisupport@tiqets.com
+  x-logo:
+    url: "https://tiqets.github.io/supplier-api/docs/tiqets-logo.png"
+    altText: "Tiqets.com Logo"
 tags:
   - name: Availability
     description: |
@@ -178,6 +181,13 @@ tags:
   - name: Booking
     description: |
       The booking endpoints allow Tiqets to create bookings by confirming reservations and, to cancel previous bookings.
+x-tagGroups:
+  - name: Supplier API Endpoints
+    tags:
+      - Availability
+      - Product Catalog
+      - Reservation
+      - Booking
 paths:
   "/v2/products":
     get:
@@ -273,154 +283,299 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AvailabilityResponse"
-              examples:
-                timeslotted:
-                  summary: Available variants for different timeslots per day
-                  value:
-                    "2022-12-19T11:00":
-                      available_tickets: 0
-                      variants: []
-                    "2022-12-19T16:30":
-                      available_tickets: 100
-                      variants:
-                        - id: "TcGz7ywywiWYURHEWD"
-                          name: Adult
-                          available_tickets: 100
-                          price:
-                            amount: "10"
-                            currency: EUR
-                        - id: "hKl5sDxP9ont4GB"
-                          name: Child
-                          available_tickets: 10
-                          price:
-                            amount: "5.75"
-                            currency: EUR
-                    2022-12-19T17:30:
-                      available_tickets: 63
-                      variants:
-                        - id: "wimaiHdm"
-                          name: Adult
-                          available_tickets: 53
-                          price:
-                            amount: "10"
-                            currency: EUR
-                        - id: "erHVNJ7KlKU4Oi4F"
-                          name: Child
-                          available_tickets: 10
-                          price:
-                            amount: "5.75"
-                            currency: EUR
-                    "2022-12-20T11:00":
-                      available_tickets: 100
-                      variants:
-                        - id: "Gtcs6N50GnSLr6J9"
-                          name: Adult
-                          available_tickets: 100
-                          price:
-                            amount: "10"
-                            currency: EUR
-                        - id: "HKBI861tu"
-                          name: Child
-                          available_tickets: 10
-                          price:
-                            amount: "5.75"
-                            currency: EUR
-                    "2022-12-20T16:30":
-                      available_tickets: 100
-                      variants:
-                        - id: "BeT4xQB"
-                          name: Adult
-                          available_tickets: 100
-                          price:
-                            amount: "10"
-                            currency: EUR
-                        - id: "el7Lje"
-                          name: Child
-                          available_tickets: 10
-                          price:
-                            amount: "5.75"
-                            currency: EUR
-                    2022-12-20T17:30:
-                      available_tickets: 63
-                      variants:
-                        - id: "0UUHZR0LlE"
-                          name: Adult
-                          available_tickets: 53
-                          price:
-                            amount: "10"
-                            currency: EUR
-                        - id: "x5kggQPJNl"
-                          name: Child
-                          available_tickets: 10
-                          price:
-                            amount: "5.75"
-                            currency: EUR
-                single_timeslot:
-                  summary: Available variants for a product with a recurring single timeslot
-                  value:
-                    "2022-12-28T11:00":
-                      available_tickets: 0
-                      variants: []
-                    "2022-12-29T11:00":
-                      available_tickets: 14
-                      variants:
-                        - id: "hdT3Hng4vsQRSkg"
-                          name: Adult
-                          available_tickets: 14
-                          price:
-                            amount: "10"
-                            currency: EUR
-                        - id: "pJEZw2DtlaKEWi"
-                          name: Child
-                          available_tickets: 10
-                          price:
-                            amount: "5.75"
-                            currency: EUR
-                non_timeslotted:
-                  summary: Available vriants for a product without timeslots
-                  value:
-                    "2022-12-19T00:00":
-                      available_tickets: 92
-                      variants:
-                        - id: "Y0J7aP1f3"
-                          name: Adult
-                          available_tickets: 82
-                          price:
-                            amount: "4.20"
-                            currency: EUR
-                        - id: "3cSQ8i"
-                          name: Child
-                          available_tickets: 10
-                          price:
-                            amount: "2.10"
-                            currency: EUR
-                past_date:
-                  summary: Availability response for a single date in the past
-                  value: {}
-                date_range_with_past_date:
-                  summary: Availability response on 2022-12-02 for a date range from 2022-12-01 until 2022-12-03
-                  value:
-                    "2022-12-02T11:00":
-                      available_tickets: 0
-                      variants: []
-                    "2022-12-03T11:00":
-                      available_tickets: 63
-                      variants:
-                        - id: "Zoe7zLmeWgu6pI"
-                          name: Adult
-                          available_tickets: 53
-                          price:
-                            amount: "10"
-                            currency: EUR
-                        - id: "I9yRjJ"
-                          name: Child
-                          available_tickets: 10
-                          price:
-                            amount: "5.75"
-                            currency: EUR
-                no_availability:
-                  summary: No available variants
-                  value: {}
+              examples: {
+                  "Product without prices": {
+                    "description": "Checking availability for a product with `provides_pricing=false`",
+                    "value": {
+                      "2022-12-19T11:00": {
+                        "available_tickets": 0,
+                        "variants": []
+                      },
+                      "2022-12-19T16:30": {
+                        "available_tickets": 100,
+                        "variants": [
+                          {
+                            "id": "TcGz7ywywiWYURHEWD",
+                            "name": "Adult",
+                            "available_tickets": 100
+                          },
+                          {
+                            "id": "hKl5sDxP9ont4GB",
+                            "name": "Child",
+                            "available_tickets": 10
+                          }
+                        ]
+                      },
+                      2022-12-19T17:30: {
+                        "available_tickets": 63,
+                        "variants": [
+                          {
+                            "id": "wimaiHdm",
+                            "name": "Adult",
+                            "available_tickets": 53
+                          },
+                          {
+                            "id": "erHVNJ7KlKU4Oi4F",
+                            "name": "Child",
+                            "available_tickets": 10
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "Product with prices": {
+                    "description": "Checking Availability for a product with a `provides_pricing=true`.",
+                    "value": {
+                      "2022-12-29T11:00": {
+                        "available_tickets": 14,
+                        "variants": [
+                          {
+                            "id": "hdT3Hng4vsQRSkg",
+                            "name": "Adult",
+                            "available_tickets": 14,
+                            "price": {
+                              "amount": "10",
+                              "currency": "EUR"
+                            }
+                          },
+                          {
+                            "id": "pJEZw2DtlaKEWi",
+                            "name": "Child",
+                            "available_tickets": 10,
+                            "price": {
+                              "amount": "5.75",
+                              "currency": "EUR"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "Product without availability": {
+                    "description": "A product that does not have availability for the specified dates.",
+                    "value": {}
+                  },
+                  "Product with timeslots": {
+                    "description": "Checking availability for a product that supports multiple timeslots per day (`use_timeslots=true`).",
+                    "value": {
+                      "2022-12-19T11:00": {
+                        "available_tickets": 0,
+                        "variants": []
+                      },
+                      "2022-12-19T16:30": {
+                        "available_tickets": 100,
+                        "variants": [
+                          {
+                            "id": "TcGz7ywywiWYURHEWD",
+                            "name": "Adult",
+                            "available_tickets": 100,
+                            "price": {
+                              "amount": "10",
+                              "currency": "EUR"
+                            }
+                          },
+                          {
+                            "id": "hKl5sDxP9ont4GB",
+                            "name": "Child",
+                            "available_tickets": 10,
+                            "price": {
+                              "amount": "5.75",
+                              "currency": "EUR"
+                            }
+                          }
+                        ]
+                      },
+                      "2022-12-19T17:30": {
+                        "available_tickets": 63,
+                        "variants": [
+                          {
+                            "id": "wimaiHdm",
+                            "name": "Adult",
+                            "available_tickets": 53,
+                            "price": {
+                              "amount": "10",
+                              "currency": "EUR"
+                            }
+                          },
+                          {
+                            "id": "erHVNJ7KlKU4Oi4F",
+                            "name": "Child",
+                            "available_tickets": 10,
+                            "price": {
+                              "amount": "5.75",
+                              "currency": "EUR"
+                            }
+                          }
+                        ]
+                      },
+                      "2022-12-20T11:00": {
+                        "available_tickets": 100,
+                        "variants": [
+                          {
+                            "id": "Gtcs6N50GnSLr6J9",
+                            "name": "Adult",
+                            "available_tickets": 100,
+                            "price": {
+                              "amount": "10",
+                              "currency": "EUR"
+                            }
+                          },
+                          {
+                            "id": "HKBI861tu",
+                            "name": "Child",
+                            "available_tickets": 10,
+                            "price": {
+                              "amount": "5.75",
+                              "currency": "EUR"
+                            }
+                          }
+                        ]
+                      },
+                      "2022-12-20T16:30": {
+                        "available_tickets": 100,
+                        "variants": [
+                          {
+                            "id": "BeT4xQB",
+                            "name": "Adult",
+                            "available_tickets": 100,
+                            "price": {
+                              "amount": "10",
+                              "currency": "EUR"
+                            }
+                          },
+                          {
+                            "id": "el7Lje",
+                            "name": "Child",
+                            "available_tickets": 10,
+                            "price": {
+                              "amount": "5.75",
+                              "currency": "EUR"
+                            }
+                          }
+                        ]
+                      },
+                      "2022-12-20T17:30": {
+                        "available_tickets": 63,
+                        "variants": [
+                          {
+                            "id": "0UUHZR0LlE",
+                            "name": "Adult",
+                            "available_tickets": 53,
+                            "price": {
+                              "amount": "10",
+                              "currency": "EUR"
+                            }
+                          },
+                          {
+                            "id": "x5kggQPJNl",
+                            "name": "Child",
+                            "available_tickets": 10,
+                            "price": {
+                              "amount": "5.75",
+                              "currency": "EUR"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "Product with a single timeslot": {
+                    "description": "Checking Availability for a product with a single timeslot (`use_timeslots=true`).",
+                    "value": {
+                      "2022-12-28T11:00": {
+                        "available_tickets": 0,
+                        "variants": []
+                      },
+                      "2022-12-29T11:00": {
+                        "available_tickets": 14,
+                        "variants": [
+                          {
+                            "id": "hdT3Hng4vsQRSkg",
+                            "name": "Adult",
+                            "available_tickets": 14,
+                            "price": {
+                              "amount": "10",
+                              "currency": "EUR"
+                            }
+                          },
+                          {
+                            "id": "pJEZw2DtlaKEWi",
+                            "name": "Child",
+                            "available_tickets": 10,
+                            "price": {
+                              "amount": "5.75",
+                              "currency": "EUR"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "Product without timeslots": {
+                    "description": "Checking Availability for a product that does not use timeslots (`use_timeslots=false`).",
+                    "value": {
+                      "2022-12-19T00:00": {
+                        "available_tickets": 92,
+                        "variants": [
+                          {
+                            "id": "Y0J7aP1f3",
+                            "name": "Adult",
+                            "available_tickets": 82,
+                            "price": {
+                              "amount": "4.20",
+                              "currency": "EUR"
+                            }
+                          },
+                          {
+                            "id": "3cSQ8i",
+                            "name": "Child",
+                            "available_tickets": 10,
+                            "price": {
+                              "amount": "2.10",
+                              "currency": "EUR"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "Availability for single date in the past": {
+                    "description": "Availability for a single date in the past",
+                    "value": {}
+                  },
+                  "Availability for date range in the past": {
+                    "description": "Checking Availability on 2022-12-02 for a date range from 2022-12-01 until 2022-12-03",
+                    "value": {
+                      "2022-12-02T11:00": {
+                        "available_tickets": 0,
+                        "variants": []
+                      },
+                      "2022-12-03T11:00": {
+                        "available_tickets": 63,
+                        "variants": [
+                          {
+                            "id": "Zoe7zLmeWgu6pI",
+                            "name": "Adult",
+                            "available_tickets": 53,
+                            "price": {
+                              "amount": "10",
+                              "currency": "EUR"
+                            }
+                          },
+                          {
+                            "id": "I9yRjJ",
+                            "name": "Child",
+                            "available_tickets": 10,
+                            "price": {
+                              "amount": "5.75",
+                              "currency": "EUR"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  },
+              }
         "400":
           description: |
             Bad request
@@ -460,96 +615,147 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/Reservation"
-            examples:
-              without_visitor_data:
-                summary: Reservation without sending visitor data
-                value:
-                  datetime: "2022-12-26T15:30"
-                  tickets:
-                    - variant_id: "njj6LScEfpp6P"
-                      quantity: 2
-                    - variant_id: "24PV7c7O"
-                      quantity: 1
-                  customer:
-                    first_name: "Jon"
-                    last_name: "Snow"
-                    email: "jon@snow.com"
-                    phone: "+48 555 555 555"
-                    country: "nl"
-              without_timeslot:
-                summary: Reservation without timeslot
-                value:
-                  datetime: "2022-12-26T00:00"
-                  tickets:
-                    - variant_id: "TkiKZwB"
-                      quantity: 2
-                    - variant_id: "GnHe4Q3AjeJtMcM59QJV"
-                      quantity: 1
-                  customer:
-                    first_name: "Jon"
-                    last_name: "Snow"
-                    email: "jon@snow.com"
-                    phone: "+48 555 555 555"
-                    country: "nl"
-              with_timeslot:
-                summary: Reservation with timeslot
-                value:
-                  datetime: "2022-12-26T17:00"
-                  tickets:
-                    - variant_id: "BzYBUNze"
-                      quantity: 2
-                    - variant_id: "kKdTxEC"
-                      quantity: 1
-                  customer:
-                    first_name: "Jon"
-                    last_name: "Snow"
-                    email: "jon@snow.com"
-                    phone: "+48 555 555 555"
-                    country: "nl"
-              with_additional_data:
-                summary: Reservation containing additional data
-                value:
-                  datetime: "2022-12-26T15:30"
-                  tickets:
-                    - variant_id: "rLVezl2rFjo5Hxtb"
-                      quantity: 2
-                      required_visitor_data:
-                        - full_name: "Jon Snow"
-                          email: "jon@snow.com"
-                        - full_name: "Tyrion Lannister"
-                          email: "tyrion@casterlyrock.com"
-                    - variant_id: "h2xK0CeEYeN7n"
-                      quantity: 1
-                      required_visitor_data:
-                          - full_name: "Arya Stark"
-                            email: "arya@north.com"
-                  customer:
-                    first_name: "Jon"
-                    last_name: "Snow"
-                    email: "jon@snow.com"
-                    phone: "+48 555 555 555"
-                    country: "nl"
-                  required_order_data:
-                    pickup_location: "Porto Azzurro Aparthotel, Malta"
-                    nationality: "USA"
-              with_additional_order_data:
-                summary: Reservation with additional order data but without visitor data.
-                value:
-                  datetime: "2022-12-26T23:30"
-                  tickets:
-                    - variant_id: "5ZSkpJSifs"
-                      quantity: 2
-                    - variant_id: "223NF5"
-                      quantity: 1
-                  customer:
-                    first_name: "Jon"
-                    last_name: "Snow"
-                    email: "jon@snow.com"
-                    phone: "+48 555 555 555"
-                    country: "nl"
-                  required_order_data:
-                    pickup_location: "Porto Azzurro Aparthotel, Malta"
-                    nationality: "USA"
+            examples: {
+              "Reservation without visitor data": {
+                "description": "Create a reservation without sending visitor data.",
+                "value": {
+                  "datetime": "2022-12-26T15:30",
+                  "tickets": [
+                    {
+                      "variant_id": "njj6LScEfpp6P",
+                      "quantity": 2
+                    },
+                    {
+                      "variant_id": "24PV7c7O",
+                      "quantity": 1
+                    }
+                  ],
+                  "customer": {
+                    "first_name": "Jon",
+                    "last_name": "Snow",
+                    "email": "jon@snow.com",
+                    "phone": "+48 555 555 555",
+                    "country": "nl"
+                  }
+                }
+              },
+              "Reservation without timeslots": {
+                "description": "Create a reservation for a product that does not support timeslots (`use_timeslots=false`).",
+                "value":{
+                  "datetime": "2022-12-26T00:00",
+                  "tickets": [
+                    {
+                      "variant_id": "TkiKZwB",
+                      "quantity": 2
+                    },
+                    {
+                      "variant_id": "GnHe4Q3AjeJtMcM59QJV",
+                      "quantity": 1
+                    }
+                  ],
+                  "customer": {
+                    "first_name": "Jon",
+                    "last_name": "Snow",
+                    "email": "jon@snow.com",
+                    "phone": "+48 555 555 555",
+                    "country": "nl"
+                  }
+                }
+              },
+              "Reservation for a product with timeslots": {
+                "description": "Create a reservation for a product that supports timeslots (`use_timeslots=true`)",
+                "value":{
+                  "datetime": "2022-12-26T17:00",
+                  "tickets": [
+                    {
+                      "variant_id": "BzYBUNze",
+                      "quantity": 2
+                    },
+                    {
+                      "variant_id": "kKdTxEC",
+                      "quantity": 1
+                    }
+                  ],
+                  "customer": {
+                    "first_name": "Jon",
+                    "last_name": "Snow",
+                    "email": "jon@snow.com",
+                    "phone": "+48 555 555 555",
+                    "country": "nl"
+                  }
+                }
+              },
+              "Reservation with additional data": {
+                "description": "Create a reservation for a product with `required_visitor_data=['full_name', 'email']` and `required_order_data=['pickup_location', 'nationality']`",
+                "value":{
+                  "datetime": "2022-12-26T15:30",
+                  "tickets": [
+                    {
+                      "variant_id": "rLVezl2rFjo5Hxtb",
+                      "quantity": 2,
+                      "required_visitor_data": [
+                        {
+                          "full_name": "Jon Snow",
+                          "email": "jon@snow.com"
+                        },
+                        {
+                          "full_name": "Tyrion Lannister",
+                          "email": "tyrion@casterlyrock.com"
+                        }
+                      ]
+                    },
+                    {
+                      "variant_id": "h2xK0CeEYeN7n",
+                      "quantity": 1,
+                      "required_visitor_data": [
+                        {
+                          "full_name": "Arya Stark",
+                          "email": "arya@north.com"
+                        }
+                      ]
+                    }
+                  ],
+                  "customer": {
+                    "first_name": "Jon",
+                    "last_name": "Snow",
+                    "email": "jon@snow.com",
+                    "phone": "+48 555 555 555",
+                    "country": "nl"
+                  },
+                  "required_order_data": {
+                    "pickup_location": "Porto Azzurro Aparthotel, Malta",
+                    "nationality": "USA"
+                  }
+                }
+              },
+              "Reservation with additional order data": {
+                "description": "Create a reservation for a product with `required_order_data=['pickup_location', 'nationality']`",
+                "value":{
+                  "datetime": "2022-12-26T23:30",
+                  "tickets": [
+                    {
+                      "variant_id": "5ZSkpJSifs",
+                      "quantity": 2
+                    },
+                    {
+                      "variant_id": "223NF5",
+                      "quantity": 1
+                    }
+                  ],
+                  "customer": {
+                    "first_name": "Jon",
+                    "last_name": "Snow",
+                    "email": "jon@snow.com",
+                    "phone": "+48 555 555 555",
+                    "country": "nl"
+                  },
+                  "required_order_data": {
+                    "pickup_location": "Porto Azzurro Aparthotel, Malta",
+                    "nationality": "USA"
+                  }
+                }
+              }
+            }
         required: true
       responses:
         "200":
@@ -558,24 +764,32 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ReservationResponse"
-              examples:
-                product_with_pricing:
-                  summary: A reservation for a product with provides_pricing set to true
-                  value:
-                    expires_at: "2019-06-30T19:45:00+00:00"
-                    reservation_id: "78940"
-                    unit_price:
-                      "TcGz7ywywiWYURHEWD":
-                        amount: "10"
-                        currency: "EUR"
-                      "hKl5sDxP9ont4GB":
-                        amount: "5.75"
-                        currency: "EUR"
-                product_without_pricing:
-                  summary: A reservation for a product with provides_pricing set to false
-                  value:
-                    expires_at: "2019-06-30T19:45:00+00:00"
-                    reservation_id: "78940"
+              examples: {
+                "product with pricing": {
+                  "description": "Response after creating a reservation for a product that provides pricing (`provides_pricing=true`).",
+                  "value": {
+                    "expires_at": "2019-06-30T19:45:00+00:00",
+                    "reservation_id": "78940",
+                    "unit_price": {
+                      "TcGz7ywywiWYURHEWD": {
+                        "amount": "10",
+                        "currency": "EUR"
+                      },
+                      "hKl5sDxP9ont4GB": {
+                        "amount": "5.75",
+                        "currency": "EUR"
+                      }
+                    }
+                  }
+                },
+                "product without pricing": {
+                  "description": "Response after creating a reservation for a product that does not provides pricing (`provides_pricing=false`).",
+                  "value": {
+                    "expires_at": "2019-06-30T19:45:00+00:00",
+                    "reservation_id": "78940"
+                  }
+                }
+              }
         "400":
           description: |
             Bad request
@@ -629,45 +843,60 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/BookingResponse"
-              examples:
-                one_barcode_per_visitor:
-                  summary: An order with one barcode per visitor
-                  value:
-                    booking_id: "657788"
-                    barcode_format: "QRCODE"
-                    barcode_scope: ticket
-                    tickets:
-                      "variant_1_id":
-                        - barcode1
-                        - barcode2
-                      "variant_2_id":
-                        - barcode3
-                one_barcode_per_order:
-                  summary: An order with a single barcode for all visitors
-                  value:
-                    booking_id: "657789"
-                    barcode_format: "QRCODE"
-                    barcode_scope: order
-                    barcode: "barcode1"
-                one_pdf_barcode_per_order:
-                  summary: An order with a single PDF barcode for all visitors
-                  value:
-                    booking_id: "657787"
-                    barcode_format: "PDF"
-                    barcode_scope: order
-                    barcode: "ZXhhbXBsZS1iYXJjb2RlLXBlci1vcmRlci0x"
-                one_pdf_barcode_per_visitor:
-                  summary: An order with one PDF barcode per visitor
-                  value:
-                    booking_id: "657787"
-                    barcode_format: "PDF"
-                    barcode_scope: ticket
-                    tickets:
-                      "variant_1_id":
-                        - "ZXhhbXBsZS12aXNpdG9yLWJhcmNvZGUtMQ=="
-                        - "ZXhhbXBsZS12aXNpdG9yLWJhcmNvZGUtMg=="
-                      "variant_2_id":
-                        - "ZXhhbXBsZS12aXNpdG9yLWJhcmNvZGUtMw=="
+              examples: {
+                "One barcode per visitor": {
+                  "description": "An order with one barcode per visitor.",
+                  "value":{
+                    "booking_id": "657788",
+                    "barcode_format": "QRCODE",
+                    "barcode_scope": "ticket",
+                    "tickets": {
+                      "variant_1_id": [
+                          "barcode1",
+                          "barcode2"
+                      ],
+                      "variant_2_id": [
+                          "barcode3"
+                      ]
+                    }
+                  }
+                },
+                "One barcode per order": {
+                  "description": "An order with a single barcode for all the visitors.",
+                  "value": {
+                    "booking_id": "657789",
+                    "barcode_format": "QRCODE",
+                    "barcode_scope": "order",
+                    "barcode": "barcode1"
+                  }
+                },
+                "One PDF barcode per order": {
+                  "description": "An order with a single PDF barcode for all the visitors.",
+                  "value": {
+                    "booking_id": "657787",
+                    "barcode_format": "PDF",
+                    "barcode_scope": "order",
+                    "barcode": "ZXhhbXBsZS1iYXJjb2RlLXBlci1vcmRlci0x"
+                  }
+                },
+                "One PDF barcode per visitor": {
+                  "description": "An order with one PDF barcode per visitor.",
+                  "value": {
+                    "booking_id": "657787",
+                    "barcode_format": "PDF",
+                    "barcode_scope": "ticket",
+                    "tickets": {
+                      "variant_1_id": [
+                          "ZXhhbXBsZS12aXNpdG9yLWJhcmNvZGUtMQ==",
+                          "ZXhhbXBsZS12aXNpdG9yLWJhcmNvZGUtMg=="
+                      ],
+                      "variant_2_id": [
+                          "ZXhhbXBsZS12aXNpdG9yLWJhcmNvZGUtMw=="
+                      ]
+                    }
+                  }
+                }
+              }
         "400":
           description: |
             Bad request


### PR DESCRIPTION
This PR introduces some minor syntactic changes to the API specification. The aim is to improve the way we display the API docs. 

- improve the examples in the endpoints by adding a longer description but shorter title. This makes it easier to read the examples w/o having to scroll horizontally.

<img width="498" alt="Screenshot 2022-12-05 at 10 02 56" src="https://user-images.githubusercontent.com/52700315/205596881-fdd2163a-9328-4737-adad-4f97a4f7f0d6.png">

- add the Tiqets logo to the top of the side menu bar

- add a section title on the side menu bar to group the endpoints: "Supplier API Endpoints"

<img width="283" alt="Screenshot 2022-12-05 at 10 02 08" src="https://user-images.githubusercontent.com/52700315/205596726-83df70f2-724a-4a29-8904-3b26350b1bb3.png">

