### PR TITLE
Added cancellation error like in V2. Also added an explicit "deprecation" message.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.6.2
+- Added a warning that this version is no longer supported for new integrators
+- Added error code 3005 "tickets already used" error, just like in V2
+
 ## 1.6.0
 
 - Add new field `order_reference` to booking step.

--- a/api.yaml
+++ b/api.yaml
@@ -2,6 +2,10 @@ openapi: 3.0.1
 info:
   title: Tiqets Supplier API
   description: |
+    ⚠️ This is Version 1 of the Tiqets Supplier API Specification!  
+    ⚠️ New implementations of this version will not be accepted and must implement [version 2](https://tiqets.github.io/supplier-api/) instead.  
+    ⚠️ Existing implementations will continue to receive support.  
+    
     The Tiqets Supplier API specification was created to allow suppliers to take charge control of the implementation process and turnaround times.
 
 
@@ -145,7 +149,7 @@ info:
 
   contact:
     email: apisupport@tiqets.com
-  version: 1.6.1
+  version: 1.6.2
 tags:
   - name: Availability
     description: |
@@ -499,6 +503,7 @@ paths:
             |                2009  | Incorrect date            | The booking can only be cancelled HOURS hours in advance                   |
             |                3003  | Already Cancelled         | The booking with ID BOOKING_ID has already been cancelled                  |
             |                3004  | Cancellation not possible | The booking can't be cancelled, the product doesn't allow cancellations    |
+            |                3005  | Tickets already used      | The booking can't be cancelled because tickets have already been used      |
           content:
             application/json:
               schema:


### PR DESCRIPTION
* Introduced the same error code for "Tickets already used" as we have in the V2 of the spec
* Added a message at the top of the documentation that clearly shows this spec is not to be implemented again. Only existing partners should use it.
* Increased version number
* Logged changes in changelog