### PR TITLE
Updating the python version for package builders

### DIFF
--- a/.github/workflows/publish-package-supplier-server-mock.yml
+++ b/.github/workflows/publish-package-supplier-server-mock.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/publish-package-supplier_api_tester.yml
+++ b/.github/workflows/publish-package-supplier_api_tester.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Python 3.7 is not working anymore with the package builder

https://github.com/Tiqets/supplier-api/actions/runs/13724679168/job/38390004093